### PR TITLE
feat(ci): extend CI/CD pipeline with EC2 instance deployment via SSH

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -90,3 +90,4 @@ jobs:
             docker rm communication_service || true
             docker pull ${{ vars.DOCKERHUB_USERNAME }}/communication-service:latest
             docker run -p 80:5000 -d -v /home/ubuntu/db:/app/db --name communication_service ${{ vars.DOCKERHUB_USERNAME }}/communication-service:latest
+            docker system prune --all --force


### PR DESCRIPTION
- Add `Deploy to EC2 Instance` step using `appleboy/ssh-action` for secure SSH access
- Use GitHub Secrets to securely store EC2 credentials (host, username, private key)
- Automate deployment to EC2 by stopping/removing old containers and pulling the latest Docker Hub image
- Run the container on port 80 with volume mapping to persist data on the EC2 instance
- Complete end-to-end CI/CD pipeline from testing, Docker Hub push, local deployment, and EC2 deployment